### PR TITLE
Enable MarkdownV2

### DIFF
--- a/lib/Service/Gateway/Telegram/Gateway.php
+++ b/lib/Service/Gateway/Telegram/Gateway.php
@@ -75,7 +75,7 @@ class Gateway implements IGateway {
 
 		$this->logger->debug("sending telegram message to $identifier");
 		try {
-			$api->sendMessage($identifier, $message);
+			$api->sendMessage($identifier, $message, 'MarkdownV2');
 		} catch (TelegramSDKException $e) {
 			$this->logger->logException($e);
 


### PR DESCRIPTION
Now messages in telegram are sent in MarkdownV2 format

Signed-off-by: Tyler Durden <41618713+TylerIO@users.noreply.github.com>